### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "clouddebugger",
     "name_pretty": "Cloud Debugger",
     "product_documentation": "cloud.google.com/debugger",
-    "client_documentation": "https://googleapis.dev/python/clouddebugger/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/clouddebugger/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ view the application state without adding logging statements.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-debugger-client.svg
    :target: https://pypi.org/project/google-cloud-debugger-client/
 .. _Cloud Debugger: https://cloud.google.com/debugger/docs
-.. _Client Library Documentation: https://googleapis.dev/python/clouddebugger/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/clouddebugger/latest
 .. _Product Documentation:  https://cloud.google.com/debugger/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.